### PR TITLE
c#, java: Don't mistake string and character constants for high bytes

### DIFF
--- a/Units/bug1777340.java.t/expected.tags
+++ b/Units/bug1777340.java.t/expected.tags
@@ -1,3 +1,3 @@
 bug1777340	input.java	/^public @interface bug1777340 {$/;"	i
+d	input.java	/^    String n() default "ninjas; monkeys!";$/;"	f	interface:bug1777340
 m	input.java	/^    String m();$/;"	m	interface:bug1777340
-Ó	Units/bug1777340.java.t/input.java	/^    String n() default "ninjas; monkeys!";$/;"	f	interface:bug1777340

--- a/c.c
+++ b/c.c
@@ -42,7 +42,8 @@
 
 #define isOneOf(c,s)        (boolean) (strchr ((s), (c)) != NULL)
 
-#define isHighChar(c)       ((c) != EOF && (unsigned char)(c) >= 0xc0)
+#define isHighChar(c)       ((c) != EOF && (unsigned int)(c) >= 0xc0 && \
+							               (unsigned int)(c) <= 0xff)
 
 /*
 *   DATA DECLARATIONS

--- a/read.h
+++ b/read.h
@@ -62,8 +62,9 @@ enum eCharacters {
 	SINGLE_QUOTE  = '\'',
 	BACKSLASH     = '\\',
 
-	STRING_SYMBOL = ('S' + 0x80),
-	CHAR_SYMBOL   = ('C' + 0x80)
+	/* symbolic representations, above 0xFF not to conflict with any byte */
+	STRING_SYMBOL = ('S' + 0xff),
+	CHAR_SYMBOL   = ('C' + 0xff)
 };
 
 /*  Maintains the state of the current source file.


### PR DESCRIPTION
Change the value of `STRING_SYMBOL` and `CHAR_SYMBOL` for them not to conflict with legitimate high bytes.

Alter C# and Java-specific checks allowing for high characters to exclude any non-byte value (anything above 0xFF).

Note: the test *bug1777340.java.t* still isn't correct.

Part of #211.