### PR TITLE
C++: support C++11 enum class/struct

### DIFF
--- a/Units/cxx11enum.cpp.d/expected.tags
+++ b/Units/cxx11enum.cpp.d/expected.tags
@@ -11,6 +11,22 @@ C_a	input.cpp	/^enum C:unsigned int {C_a, C_b, C_c};$/;"	e	enum:C	file:
 C_b	input.cpp	/^enum C:unsigned int {C_a, C_b, C_c};$/;"	e	enum:C	file:
 C_c	input.cpp	/^enum C:unsigned int {C_a, C_b, C_c};$/;"	e	enum:C	file:
 D	input.cpp	/^  enum D:int {a, b, c};$/;"	g	class:Foo	file:
+EC1	input.cpp	/^enum class EC1:short {EC1_a, EC1_b, EC1_c};$/;"	g	file:
+EC1_a	input.cpp	/^enum class EC1:short {EC1_a, EC1_b, EC1_c};$/;"	e	enum:EC1	file:
+EC1_b	input.cpp	/^enum class EC1:short {EC1_a, EC1_b, EC1_c};$/;"	e	enum:EC1	file:
+EC1_c	input.cpp	/^enum class EC1:short {EC1_a, EC1_b, EC1_c};$/;"	e	enum:EC1	file:
+EC2	input.cpp	/^  enum class EC2:unsigned {EC2_a, EC2_b, EC2_c};$/;"	g	class:Foo	file:
+EC2_a	input.cpp	/^  enum class EC2:unsigned {EC2_a, EC2_b, EC2_c};$/;"	e	enum:Foo::EC2	file:
+EC2_b	input.cpp	/^  enum class EC2:unsigned {EC2_a, EC2_b, EC2_c};$/;"	e	enum:Foo::EC2	file:
+EC2_c	input.cpp	/^  enum class EC2:unsigned {EC2_a, EC2_b, EC2_c};$/;"	e	enum:Foo::EC2	file:
+ES1	input.cpp	/^enum struct ES1:unsigned {ES1_a, ES1_b, ES1_c};$/;"	g	file:
+ES1_a	input.cpp	/^enum struct ES1:unsigned {ES1_a, ES1_b, ES1_c};$/;"	e	enum:ES1	file:
+ES1_b	input.cpp	/^enum struct ES1:unsigned {ES1_a, ES1_b, ES1_c};$/;"	e	enum:ES1	file:
+ES1_c	input.cpp	/^enum struct ES1:unsigned {ES1_a, ES1_b, ES1_c};$/;"	e	enum:ES1	file:
+ES2	input.cpp	/^  enum struct ES2:int {ES2_a, ES2_b, ES2_c};$/;"	g	class:Foo	file:
+ES2_a	input.cpp	/^  enum struct ES2:int {ES2_a, ES2_b, ES2_c};$/;"	e	enum:Foo::ES2	file:
+ES2_b	input.cpp	/^  enum struct ES2:int {ES2_a, ES2_b, ES2_c};$/;"	e	enum:Foo::ES2	file:
+ES2_c	input.cpp	/^  enum struct ES2:int {ES2_a, ES2_b, ES2_c};$/;"	e	enum:Foo::ES2	file:
 Foo	input.cpp	/^class Foo {$/;"	c	file:
 a	input.cpp	/^  enum D:int {a, b, c};$/;"	e	enum:Foo::D	file:
 b	input.cpp	/^  enum D:int {a, b, c};$/;"	e	enum:Foo::D	file:

--- a/Units/cxx11enum.cpp.d/input.cpp
+++ b/Units/cxx11enum.cpp.d/input.cpp
@@ -2,8 +2,12 @@
 enum A:int {A_a, A_b, A_c};
 enum B:long {B_a, B_b, B_c};
 enum C:unsigned int {C_a, C_b, C_c};
+enum class EC1:short {EC1_a, EC1_b, EC1_c};
+enum struct ES1:unsigned {ES1_a, ES1_b, ES1_c};
 
 class Foo {
   enum D:int {a, b, c};
+  enum class EC2:unsigned {EC2_a, EC2_b, EC2_c};
+  enum struct ES2:int {ES2_a, ES2_b, ES2_c};
   virtual void foo(enum D a);
 };

--- a/c.c
+++ b/c.c
@@ -1886,6 +1886,12 @@ static void processInterface (statementInfo *const st)
 	st->declaration = DECL_INTERFACE;
 }
 
+static void checkIsClassEnum (statementInfo *const st, const declType decl)
+{
+	if (! isLanguage (Lang_cpp) || st->declaration != DECL_ENUM)
+		st->declaration = decl;
+}
+
 static void processToken (tokenInfo *const token, statementInfo *const st)
 {
 	switch (token->keyword)        /* is it a reserved word? */
@@ -1899,7 +1905,7 @@ static void processToken (tokenInfo *const token, statementInfo *const st)
 		case KEYWORD_BIT:       st->declaration = DECL_BASE;            break;
 		case KEYWORD_CATCH:     skipParens (); skipBraces ();           break;
 		case KEYWORD_CHAR:      st->declaration = DECL_BASE;            break;
-		case KEYWORD_CLASS:     st->declaration = DECL_CLASS;           break;
+		case KEYWORD_CLASS:     checkIsClassEnum (st, DECL_CLASS);      break;
 		case KEYWORD_CONST:     st->declaration = DECL_BASE;            break;
 		case KEYWORD_DOUBLE:    st->declaration = DECL_BASE;            break;
 		case KEYWORD_ENUM:      st->declaration = DECL_ENUM;            break;
@@ -1927,7 +1933,7 @@ static void processToken (tokenInfo *const token, statementInfo *const st)
 		case KEYWORD_SHORT:     st->declaration = DECL_BASE;            break;
 		case KEYWORD_SIGNED:    st->declaration = DECL_BASE;            break;
 		case KEYWORD_STRING:    st->declaration = DECL_BASE;            break;
-		case KEYWORD_STRUCT:    st->declaration = DECL_STRUCT;          break;
+		case KEYWORD_STRUCT:    checkIsClassEnum (st, DECL_CLASS);      break;
 		case KEYWORD_TASK:      st->declaration = DECL_TASK;            break;
 		case KEYWORD_THROWS:    discardTypeList (token);                break;
 		case KEYWORD_UNION:     st->declaration = DECL_UNION;           break;

--- a/docs/tracking.rst
+++ b/docs/tracking.rst
@@ -382,6 +382,7 @@ These changes have been merged:
 * Fix regex callback match count - https://github.com/fishman/ctags/pull/104 
 * SQL tags are stored with scopes instead of "tablename.field" - https://github.com/fishman/ctags/pull/100
 * Some fixes for D parser
+* C++11's enum class/struct support
 
 
 `VIM-Japan <https://github.com/vim-jp/ctags/>`_


### PR DESCRIPTION
The modifications to c.c are directly taken from Geany (commit 6c7f69),
docs/tracking.rst has been updated accordingly.

cxx11enum.cpp unit has also been updated to include enum class/struct's.