### PR TITLE
Fix filename references to files in docs/

### DIFF
--- a/NEWS.fishman
+++ b/NEWS.fishman
@@ -1,1 +1,1 @@
-see docs/f-news.rst.
+see docs/news.rst.

--- a/TRACKING
+++ b/TRACKING
@@ -1,1 +1,1 @@
-see docs/f-tracking.rst.
+see docs/tracking.rst.

--- a/Units/README
+++ b/Units/README
@@ -1,1 +1,1 @@
-see docs/f-units.rst.
+see docs/units.rst.

--- a/data/optlib/README
+++ b/data/optlib/README
@@ -1,1 +1,1 @@
-see f-optlib.rst.
+see optlib.rst.

--- a/misc/units
+++ b/misc/units
@@ -63,8 +63,8 @@ L_FAILED_BY_TIMEED_OUT=
 #
 # TODO
 #
-#  * write new class 'r' (category directory) to f-units.rst.
-#  * write new class 'v' (skip the checkin by valgrind) to f-units.rst.
+#  * write new class 'r' (category directory) to units.rst.
+#  * write new class 'v' (skip the checkin by valgrind) to units.rst.
 #
 action_help ()
 {


### PR DESCRIPTION
The "f-" prefix has been discarded in git commit
f439b71b949adadba4c83df7ae033a8f8a7015ec on 2014-12-23.