### PR TITLE
python: do not ignore the character after a skipped string

### DIFF
--- a/Units/py-skipped-string.d/expected.tags
+++ b/Units/py-skipped-string.d/expected.tags
@@ -1,0 +1,3 @@
+f1	input.py	/^def f1():$/;"	f
+f2	input.py	/^def f2():$/;"	f
+f3	input.py	/^def f3():$/;"	f

--- a/Units/py-skipped-string.d/input.py
+++ b/Units/py-skipped-string.d/input.py
@@ -1,0 +1,30 @@
+# triple start string immediately after a normal string not detected
+
+def f1():
+    ''"""
+    The string above was not detected as triple start string,
+    but the one below instead.
+    """
+    print "f1"
+
+def f2():
+    ''"""
+    The string above was then detected as end string,
+    and the one below as start string again.
+    """
+    print "f2"
+
+def f3():
+    """
+    The string below is prepared so that ctags with the bug does not start a
+    new triple string. For a clean precondition for the next test.
+    ''"""
+    print "f3"
+
+# normal string immediately after a normal string not detected
+
+''" import os\
+"
+
+""' def fX():\
+'

--- a/python.c
+++ b/python.c
@@ -266,6 +266,8 @@ static const char *skipEverything (const char *cp)
 		}
 		if (isIdentifierFirstCharacter ((int) *cp))
 			return cp;
+		if (match)
+			cp--; /* avoid jumping over the character after a skipped string */
 	}
 	return cp;
 }
@@ -551,6 +553,7 @@ static char const *find_triple_start(char const *string, char const **which)
 			}
 			cp = skipString(cp);
 			if (!*cp) break;
+			cp--; /* avoid jumping over the character after a skipped string */
 		}
 	}
 	return NULL;


### PR DESCRIPTION
This fixes missing or too much entries in the tags file.