### PR TITLE
units: Exit with an error if `fuzz` failed

### DIFF
--- a/misc/units
+++ b/misc/units
@@ -1148,12 +1148,17 @@ fuzz_lang ()
     local dir="$2"
     shift 2
     local f
+    local r=0
 
     [ "${QUIET}" = 'yes' ] || printf '%-60s\n' "Semi-fuzzing (${lang})"
     for f in $(find "${dir}" -type f -name 'input.*'); do
-	fuzz_lang_file "${lang}" "${f}"
+	if ! fuzz_lang_file "${lang}" "${f}"; then
+	    r=1
+	    break
+	fi
     done
     [ "${QUIET}" = 'yes' ] || echo
+    return $r
 }
 
 action_fuzz ()


### PR DESCRIPTION
This is important for scripting, and especially for Make integration so
failures are recognized.