### PR TITLE
Add a unit based on patch sf.patch:77's  test.cpp

### DIFF
--- a/Units/variables-prototypes.cpp.b/args.ctags
+++ b/Units/variables-prototypes.cpp.b/args.ctags
@@ -1,0 +1,1 @@
+--c++-kinds=+pl --fields=+S

--- a/Units/variables-prototypes.cpp.b/expected.tags
+++ b/Units/variables-prototypes.cpp.b/expected.tags
@@ -1,0 +1,94 @@
+A1	input.cpp	/^int  A1 = i < 7 ? i : 7;$/;"	v
+A2	input.cpp	/^int  A2 = 8;$/;"	v
+A3	input.cpp	/^int  A3 = 9;$/;"	v
+A4	input.cpp	/^int  A4 = p->data;$/;"	v
+A5	input.cpp	/^int  A5 = 8;$/;"	v
+A6	input.cpp	/^int ( *A6 )( int, char ** ) = &main;$/;"	v
+A7	input.cpp	/^int  A7( short ( *p )( int ) );$/;"	p	file:	signature:( short ( *p )( int ) )
+B1	input.cpp	/^const char *B1( "uuu" );                \/\/variable$/;"	v
+B2	input.cpp	/^int B2( int ooo, const char* o );       \/\/prototype$/;"	p	file:	signature:( int ooo, const char* o )
+B3	input.cpp	/^int B3( int( 7 ) );                     \/\/variable$/;"	v
+C1	input.cpp	/^int C1( a >> ooo );                     \/\/variable$/;"	v
+C2	input.cpp	/^int C2( int * h );                      \/\/prototype$/;"	p	file:	signature:( int * h )
+C3	input.cpp	/^int C3( std::map<int>( 9 ) );           \/\/variable$/;"	v
+C4	input.cpp	/^int C4( std::map<int> a );              \/\/prototype$/;"	p	file:	signature:( std::map<int> a )
+C5	input.cpp	/^int C5( map<int>  & a );                \/\/prototype$/;"	p	file:	signature:( map<int> & a )
+C6	input.cpp	/^int C6( ooo & a );                      \/\/prototype$/;"	p	file:	signature:( ooo & a )
+C7	input.cpp	/^int C7( int & a );                      \/\/prototype$/;"	p	file:	signature:( int & a )
+C8	input.cpp	/^int C8( map<int> a );                   \/\/prototype$/;"	p	file:	signature:( map<int> a )
+C9	input.cpp	/^int C9( int a );                        \/\/prototype$/;"	p	file:	signature:( int a )
+D1	input.cpp	/^ind D1( a * 2 );                        \/\/variable$/;"	v
+D2	input.cpp	/^ind D2( "a" * 2 );                      \/\/variable$/;"	v
+D3	input.cpp	/^int D3( *j );                           \/\/variable$/;"	v
+F1	input.cpp	/^int F1( SomeType (*p)( int ) );         \/\/prototype$/;"	p	file:	signature:( SomeType (*p)( int ) )
+F2	input.cpp	/^SomeType (*F2)( int o );                \/\/variable$/;"	v
+F3	input.cpp	/^int F3( std::map<int> & a );            \/\/prototype$/;"	p	file:	signature:( std::map<int> & a )
+G1	input.cpp	/^int G1( SomeType a );                   \/\/prototype$/;"	p	file:	signature:( SomeType a )
+H1	input.cpp	/^char H1( const char *a = "a" );         \/\/prototype$/;"	p	file:	signature:( const char *a = <String> )
+H2	input.cpp	/^int H2();                               \/\/prototype$/;"	p	file:	signature:()
+H3	input.cpp	/^char H3( double );                      \/\/prototype$/;"	p	file:	signature:( double )
+H4	input.cpp	/^int H4( h u );                          \/\/prototype$/;"	p	file:	signature:( h u )
+P1	input.cpp	/^int (*P1)( int o );                     \/\/variable$/;"	v
+V4	input.cpp	/^int V4( iii( 'o' ) );                   \/\/variable$/;"	v
+V5	input.cpp	/^int V5( iii( o ) );                     \/\/variable$/;"	v
+V6	input.cpp	/^int V6( int (*p)( int ) );              \/\/prototype$/;"	p	file:	signature:( int (*p)( int ) )
+V7	input.cpp	/^int V7( 89 );                           \/\/variable$/;"	v
+V8	input.cpp	/^int V8( ooo );                          \/\/variable$/;"	v
+W1	input.cpp	/^int W1 __ARGS (( int a )){}             \/\/function$/;"	f	signature:( int a )
+W2	input.cpp	/^int W2 (( a - 5 ) \/ 6 );                \/\/variable$/;"	v
+X1	input.cpp	/^int X1( a.b );                          \/\/variable$/;"	v
+X2	input.cpp	/^int X2( a->b );                         \/\/variable$/;"	v
+X3	input.cpp	/^int X3( NS::a  b );                     \/\/prototype$/;"	p	file:	signature:( NS::a b )
+X4	input.cpp	/^int X4( a ^ b );                        \/\/variable $/;"	v
+X5	input.cpp	/^int X5( a ^ 6 );                        \/\/variable$/;"	v
+X6	input.cpp	/^int X6( a | b );                        \/\/variable$/;"	v
+X8	input.cpp	/^int X8( a & b & 2 );                    \/\/variable$/;"	v
+X9	input.cpp	/^int X9( a && b );                       \/\/variable$/;"	v
+a1	input.cpp	/^    int  a1 = i < 7 ? i : 7;$/;"	l
+a2	input.cpp	/^    int  a2 = 8;$/;"	l
+a3	input.cpp	/^    int  a3 = 9;$/;"	l
+a4	input.cpp	/^    int  a4 = p->data;$/;"	l
+a5	input.cpp	/^    int  a5 = 8;$/;"	l
+a6	input.cpp	/^    int ( *a6 )( int, char ** ) = &main;$/;"	l
+a7	input.cpp	/^    int  a7( short ( *p )( int ) );$/;"	p	file:	signature:( short ( *p )( int ) )
+a8	input.cpp	/^    short a8 = i;$/;"	l
+b1	input.cpp	/^    const char *b1( "uuu" );                \/\/variable$/;"	l
+b2	input.cpp	/^    int b2( int ooo, const char* o );       \/\/prototype$/;"	p	file:	signature:( int ooo, const char* o )
+b3	input.cpp	/^    int b3( int( 7 ) );                     \/\/variable$/;"	l
+c1	input.cpp	/^    int c1( a >> ooo );                     \/\/variable$/;"	l
+c2	input.cpp	/^    int c2( int * h );                      \/\/prototype$/;"	p	file:	signature:( int * h )
+c3	input.cpp	/^    int c3( std::map<int>( 9 ) );           \/\/variable$/;"	l
+c4	input.cpp	/^    int c4( std::map<int> a );              \/\/prototype$/;"	p	file:	signature:( std::map<int> a )
+c5	input.cpp	/^    int c5( map<int>  & a );                \/\/prototype$/;"	p	file:	signature:( map<int> & a )
+c6	input.cpp	/^    int c6( ooo & a );                      \/\/prototype$/;"	p	file:	signature:( ooo & a )
+c7	input.cpp	/^    int c7( int & a );                      \/\/prototype$/;"	p	file:	signature:( int & a )
+c8	input.cpp	/^    int c8( map<int> a );                   \/\/prototype$/;"	p	file:	signature:( map<int> a )
+c9	input.cpp	/^    int c9( int a );                        \/\/prototype$/;"	p	file:	signature:( int a )
+d1	input.cpp	/^    ind d1( a * 2 );                        \/\/variable$/;"	l
+d2	input.cpp	/^    ind d2( "a" * 2 );                      \/\/variable$/;"	l
+d3	input.cpp	/^    int d3( *j );                           \/\/variable$/;"	l
+f1	input.cpp	/^    int f1( SomeType (*p)( int ) );         \/\/prototype$/;"	p	file:	signature:( SomeType (*p)( int ) )
+f2	input.cpp	/^    SomeType (*f2)( int o );                \/\/variable$/;"	l
+f3	input.cpp	/^    int f3( std::map<int> & a );            \/\/prototype$/;"	p	file:	signature:( std::map<int> & a )
+g1	input.cpp	/^    int g1( SomeType a );                   \/\/prototype$/;"	p	file:	signature:( SomeType a )
+h1	input.cpp	/^    char h1( const char *a = "a" );         \/\/prototype$/;"	p	file:	signature:( const char *a = <String> )
+h2	input.cpp	/^    int h2();                               \/\/prototype$/;"	p	file:	signature:()
+h3	input.cpp	/^    char h3( double );                      \/\/prototype$/;"	p	file:	signature:( double )
+h4	input.cpp	/^    int h4( h u );                          \/\/prototype$/;"	p	file:	signature:( h u )
+main	input.cpp	/^int  main( int  argc, char ** argv )$/;"	f	signature:( int argc, char ** argv )
+p1	input.cpp	/^    int (*p1)( int o );                     \/\/variable$/;"	l
+v4	input.cpp	/^    int v4( iii( 'o' ) );                   \/\/variable$/;"	l
+v5	input.cpp	/^    int v5( iii( o ) );                     \/\/variable$/;"	l
+v6	input.cpp	/^    int v6( int (*p)( int ) );              \/\/prototype$/;"	p	file:	signature:( int (*p)( int ) )
+v7	input.cpp	/^    int v7( 89 );                           \/\/variable$/;"	l
+v8	input.cpp	/^    int v8( ooo );                          \/\/variable$/;"	l
+w1	input.cpp	/^    int w1 __ARGS (( int a ));              \/\/prototype$/;"	p	file:	signature:( int a )
+w2	input.cpp	/^    int w2 (( a - 5 ) \/ 6 );                \/\/variable$/;"	l
+x1	input.cpp	/^    int x1( a.b );                          \/\/variable$/;"	l
+x2	input.cpp	/^    int x2( a->b );                         \/\/variable$/;"	l
+x3	input.cpp	/^    int x3( NS::a  b );                     \/\/prototype$/;"	p	file:	signature:( NS::a b )
+x4	input.cpp	/^    int x4( a ^ b );                        \/\/variable $/;"	l
+x5	input.cpp	/^    int x5( a ^ 6 );                        \/\/variable$/;"	l
+x6	input.cpp	/^    int x6( a | b );                        \/\/variable$/;"	l
+x8	input.cpp	/^    int x8( a & b & 2 );                    \/\/variable$/;"	l
+x9	input.cpp	/^    int x9( a && b );                       \/\/variable$/;"	l

--- a/Units/variables-prototypes.cpp.b/input.cpp
+++ b/Units/variables-prototypes.cpp.b/input.cpp
@@ -1,0 +1,152 @@
+int  main( int  argc, char ** argv )
+{
+    // 1. Angle brackets handling bug
+    // As of now a2, a3 and a4 will be skipped
+
+    int  a1 = i < 7 ? i : 7;
+    int  a2 = 8;
+    int  a3 = 9;
+    int  a4 = p->data;
+    int  a5 = 8;
+
+
+    // 2. Function pointer decl bug
+    // As of now a6 will be skipped
+
+    int ( *a6 )( int, char ** ) = &main;
+
+
+    // 3. Wrong prototype will be written
+    // As of now prototype will be ( SomeType ( p )( int ) )
+
+    int  a7( short ( *p )( int ) );
+
+
+    // 4. DECL_IGNORE bug
+    // As of now a8 will be skipped
+
+    if ( argc > 0 )
+        return 0;
+
+    short a8 = i;
+
+
+    // 5. Local variables support
+	// As of now all the identifiers below are either reported as prototypes,
+	// or not recognized at all
+	// The comments on the right specify which kind of tag should be generated
+
+    const char *b1( "uuu" );                //variable
+    int b2( int ooo, const char* o );       //prototype
+    int b3( int( 7 ) );                     //variable
+    int c1( a >> ooo );                     //variable
+    int c2( int * h );                      //prototype
+    int c3( std::map<int>( 9 ) );           //variable
+    int c4( std::map<int> a );              //prototype
+    int c5( map<int>  & a );                //prototype
+    int c6( ooo & a );                      //prototype
+    int c7( int & a );                      //prototype
+    int c8( map<int> a );                   //prototype
+    int c9( int a );                        //prototype
+    ind d1( a * 2 );                        //variable
+    ind d2( "a" * 2 );                      //variable
+    int d3( *j );                           //variable
+    int f1( SomeType (*p)( int ) );         //prototype
+    SomeType (*f2)( int o );                //variable
+    int f3( std::map<int> & a );            //prototype
+    int g1( SomeType a );                   //prototype
+	// As of now, the signature of h1 will be "( int a = R )",
+	// 'R' is to be replaced by something clearer to denote a
+	// string literal
+    char h1( const char *a = "a" );         //prototype
+    int h2();                               //prototype
+    char h3( double );                      //prototype
+    int h4( h u );                          //prototype
+    int (*p1)( int o );                     //variable
+    int v4( iii( 'o' ) );                   //variable
+    int v5( iii( o ) );                     //variable
+    int v6( int (*p)( int ) );              //prototype
+    int v7( 89 );                           //variable
+    int v8( ooo );                          //variable
+    // __ARGS(x) is a compatibility macro which optionally
+	// expands to x when prototypes are supported, so
+	// w1 should be parsed as a prototype
+    int w1 __ARGS (( int a ));              //prototype
+    int w2 (( a - 5 ) / 6 );                //variable
+    int x1( a.b );                          //variable
+    int x2( a->b );                         //variable
+    int x3( NS::a  b );                     //prototype
+    int x4( a ^ b );                        //variable 
+    int x5( a ^ 6 );                        //variable
+    int x6( a | b );                        //variable
+	// As of now, x7 is not recognized at all; it should
+	// give a variable tag but it's tricky to get it
+	// right because of '&' which suggests a prototype,
+	// so for now let's just ignore it
+    //int x7( a & b & c );                  //variable
+    int x8( a & b & 2 );                    //variable
+    int x9( a && b );                       //variable
+}
+
+/* 
+ * Below is a copy/paste of the local identifiers above made uppercase,
+ * but with a global scope instead.
+ */
+
+// 1. Angle brackets handling bug
+int  A1 = i < 7 ? i : 7;
+int  A2 = 8;
+int  A3 = 9;
+int  A4 = p->data;
+int  A5 = 8;
+
+
+// 2. Function pointer decl bug
+int ( *A6 )( int, char ** ) = &main;
+
+
+// 3. Wrong prototype will be written
+int  A7( short ( *p )( int ) );
+
+
+// 4. Global variables support
+const char *B1( "uuu" );                //variable
+int B2( int ooo, const char* o );       //prototype
+int B3( int( 7 ) );                     //variable
+int C1( a >> ooo );                     //variable
+int C2( int * h );                      //prototype
+int C3( std::map<int>( 9 ) );           //variable
+int C4( std::map<int> a );              //prototype
+int C5( map<int>  & a );                //prototype
+int C6( ooo & a );                      //prototype
+int C7( int & a );                      //prototype
+int C8( map<int> a );                   //prototype
+int C9( int a );                        //prototype
+ind D1( a * 2 );                        //variable
+ind D2( "a" * 2 );                      //variable
+int D3( *j );                           //variable
+int F1( SomeType (*p)( int ) );         //prototype
+SomeType (*F2)( int o );                //variable
+int F3( std::map<int> & a );            //prototype
+int G1( SomeType a );                   //prototype
+char H1( const char *a = "a" );         //prototype
+int H2();                               //prototype
+char H3( double );                      //prototype
+int H4( h u );                          //prototype
+int (*P1)( int o );                     //variable
+int V4( iii( 'o' ) );                   //variable
+int V5( iii( o ) );                     //variable
+int V6( int (*p)( int ) );              //prototype
+int V7( 89 );                           //variable
+int V8( ooo );                          //variable
+int W1 __ARGS (( int a )){}             //function
+int W2 (( a - 5 ) / 6 );                //variable
+int X1( a.b );                          //variable
+int X2( a->b );                         //variable
+int X3( NS::a  b );                     //prototype
+int X4( a ^ b );                        //variable 
+int X5( a ^ 6 );                        //variable
+int X6( a | b );                        //variable
+//int X7( a & b & c );                  //variable
+int X8( a & b & 2 );                    //variable
+int X9( a && b );                       //variable


### PR DESCRIPTION
Patch #77 fixes an important number of issues with the way variables
(local and global) and prototypes are parsed in C and above all C++.

This commit adds a new unit (marked as known bug) based on the test file
provided with patch #77, removing some cases which weren't valid C++ and
duplicating all the identifiers as global variables, on top of local
variables.

The expected.tags file has been generated with a version of ctags where
patch #77 has been applied, with the following modifications:
- An issue with an invalid character in signatures has been worked
  around by the patch author @lyokha, see issue #234
- I removed the support for MS.Net, so that identifiers such as
  int x4(5 ^ 4); are effectively recognized as variables (it was
  just a matter of uncommenting a "case '^':" in the patch).