### PR TITLE
Check file error flag in makeTagEntry function

### DIFF
--- a/entry.c
+++ b/entry.c
@@ -835,6 +835,12 @@ extern void makeTagEntry (const tagEntryInfo *const tag)
 		else
 			length = writeCtagsEntry (tag);
 
+		if (ferror (TagFile.fp))
+		{
+			error (FATAL | PERROR, "cannot write tag file");
+			exit (1);
+		}
+
 		++TagFile.numTags.added;
 		rememberMaxLengths (strlen (tag->name), (size_t) length);
 		DebugStatement ( fflush (TagFile.fp); )


### PR DESCRIPTION
Possibly fixes issue: ctags might fail silently if /tmp is full #202