### PR TITLE
change vs2013 debug configuration

### DIFF
--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -70,6 +70,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">


### PR DESCRIPTION
Linker error: ada.obj : warning LNK4075: ignoring '/EDITANDCONTINUE' due
to '/SAFESEH' specification
So for debug mode I changed in Linker settings /SAFESEH to false.
In release mode it can stay true, since it does not create warnings.

Any comments are welcome, I mostly use gcc. All I can say the warning gone and you can still debug.
https://msdn.microsoft.com/en-us/library/9a89h429.aspx