### PR TITLE
vs2013 errno defined twice

### DIFF
--- a/fnmatch/fnmatch.c
+++ b/fnmatch/fnmatch.c
@@ -33,7 +33,9 @@ Library General Public License for more details.  */
 #include <errno.h>
 #include <fnmatch.h>
 
-#if !defined(__GNU_LIBRARY__) && !defined(STDC_HEADERS)
+#if !defined(__GNU_LIBRARY__) \
+	&& !defined(STDC_HEADERS) \
+	&& !defined(_CRT_ERRNO_DEFINED)
 extern int errno;
 #endif
 


### PR DESCRIPTION
warning C4273: '_errno' : inconsistent dll linkage
...\12.0\vc\include\errno.h(31) : see previous definition of '_errno'

If _CRT_ERRNO_DEFINED is defined then do not define it again.