### PR TITLE
Set timeout value to 0 if timeout command is not available in a test environment

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -367,7 +367,7 @@ check: units
 #
 # SHELL must be dash or bash.
 #
-fuzz: TIMEOUT := 1
+fuzz: TIMEOUT := $(shell which timeout > /dev/null 2>&1 && echo 1 || echo 0)
 fuzz: $(CTAGS_TEST)
 	@ \
 	c="misc/units fuzz \
@@ -392,7 +392,7 @@ noise: $(CTAGS_TEST)
 #
 # UNITS Target
 #
-units: TIMEOUT := 5
+units: TIMEOUT := $(shell which timeout > /dev/null 2>&1 && echo 5 || echo 0)
 units: $(CTAGS_TEST)
 	@ \
 	c="misc/units run \


### PR DESCRIPTION
(It seems that macosx at travis doesn't have timeout command.)