### PR TITLE
Use `timeout --version` to check for GNU timeout

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -367,7 +367,7 @@ check: units
 #
 # SHELL must be dash or bash.
 #
-fuzz: TIMEOUT := $(shell which timeout > /dev/null 2>&1 && echo 1 || echo 0)
+fuzz: TIMEOUT := $(shell timeout --version > /dev/null 2>&1 && echo 1 || echo 0)
 fuzz: $(CTAGS_TEST)
 	@ \
 	c="misc/units fuzz \
@@ -392,7 +392,7 @@ noise: $(CTAGS_TEST)
 #
 # UNITS Target
 #
-units: TIMEOUT := $(shell which timeout > /dev/null 2>&1 && echo 5 || echo 0)
+units: TIMEOUT := $(shell timeout --version > /dev/null 2>&1 && echo 5 || echo 0)
 units: $(CTAGS_TEST)
 	@ \
 	c="misc/units run \


### PR DESCRIPTION
Fixes `make units` on MSYS 1.0.
Note: `which timeout` succeeds even for MS timeout (c:\windows\system32\timeout.exe), which is not compatible.

(Follows on from #254).