### PR TITLE
Fix environ retrieval on OSX

### DIFF
--- a/main.c
+++ b/main.c
@@ -464,7 +464,11 @@ static void sanitizeEnviron (void)
 #if HAVE_DECL___ENVIRON
 	e = __environ;
 #elif HAVE_DECL__NSGETENVIRON
-	e = _NSGetEnviron();
+{
+	char ***ep = _NSGetEnviron();
+	if (ep)
+		e = *ep;
+}
 #endif
 
 	if (!e)


### PR DESCRIPTION
_NSGetEnviron() returns a pointer to the environ variable, not the
environ variable itself.

---

Issue #93 lead to 1f00f07bbfabfaa275ad8ac1dffc6084415c3724, but [a recent successful Travis OSX build](https://travis-ci.org/fishman/ctags/jobs/52533979#L162) shows a very suspicious compiler warning:

```
main.c:467:4: warning: incompatible pointer types assigning to 'char **' from 'char ***'; dereference with * [-Wincompatible-pointer-types]
        e = _NSGetEnviron();
          ^ ~~~~~~~~~~~~~~~
            *
```

I couldn't find the canonical documentation for `_NSGetEnviron()`, but all other use of it I saw indeed dereference the return value<sup>[1](https://git.gnome.org/browse/glib/tree/glib/genviron.c#n307), [2](http://www.open-mpi.org/community/lists/devel/2007/05/1596.php), [3](https://lists.torproject.org/pipermail/tor-commits/2012-February/039848.html)</sup>.

Though **beware** that I did **not** test this, as I don't have access to an OSX machine.  So it'd be great if someone could try it out first -- especially with something that would actually trigger something visible in that code, like this:
```console
$ SOMETHING='() { ;echo hello;' ./ctags --version >/dev/null
ctags: Warning: reset environment: SOMETHING=() { ;echo hello;
```