### PR TITLE
Auto-detect missing coffeetags under rbenv

### DIFF
--- a/libexec/drivers/coffeetags
+++ b/libexec/drivers/coffeetags
@@ -27,9 +27,13 @@
 #
 #
 
-if ! type coffeetags > /dev/null 2>&1; then
-    exit 77
-fi
+{
+    if  [[ (! $(type coffeetags)) || \
+        ($(type rbenv) && ! $(rbenv which coffeetags)) ]]
+    then
+        exit 77
+    fi
+} > /dev/null 2>&1
 
 case "$1" in
     --list-kinds*)

--- a/libexec/drivers/coffeetags
+++ b/libexec/drivers/coffeetags
@@ -28,10 +28,16 @@
 #
 
 {
-    if  [[ (! $(type coffeetags)) || \
-        ($(type rbenv) && ! $(rbenv which coffeetags)) ]]
-    then
-        exit 77
+    COMMAND_NOT_FOUND=77
+
+    if type rbenv; then
+        if ! rbenv which coffeetags; then
+            exit ${COMMAND_NOT_FOUND}
+        fi
+    else
+        if ! type coffeetags; then
+            exit ${COMMAND_NOT_FOUND}
+        fi
     fi
 } > /dev/null 2>&1
 


### PR DESCRIPTION
Due to the way executables are installed by rbenv, `type coffeetags`
returns true if coffeetags executable is missing in the current ruby
version but is available in one of the other installed rubies.

This commit fixes this issue by explicitly checking rbenv for the
availability of the coffeetags executable within the current ruby
version.