### PR TITLE
Change kind names for Erlang ctags parser

### DIFF
--- a/erlang.c
+++ b/erlang.c
@@ -32,8 +32,8 @@ static kindOption ErlangKinds[] = {
 	{TRUE, 'd', "macro",    "macro definitions"},
 	{TRUE, 'f', "function", "functions"},
 	{TRUE, 'm', "module",   "modules"},
-	{TRUE, 'r', "record",   "record definitions"},
-	{TRUE, 't', "type",     "type definitions"},
+	{TRUE, 'r', "struct",   "record definitions"},
+	{TRUE, 't', "typedef",     "type definitions"},
 };
 
 /*


### PR DESCRIPTION
... so the tags will appear in Geany.

I've requested some changes at https://github.com/geany/geany/pull/445.
This is the contribution upstream. Thanks. 

