### PR TITLE
Regenerate the build system whenever its sources changed

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -170,6 +170,12 @@ $(OBJECTS): $(HEADERS) config.h Makefile
 Makefile: Makefile.in config.status
 	./config.status --file $@
 
+# Regenerate the build system whenever it changed
+config.status: configure
+	./config.status --recheck
+configure: configure.ac
+	autoreconf -vi
+
 #
 # generic install rules
 #


### PR DESCRIPTION
Regenerate the build system out of its sources when it changed, to keep
it automatically up to date.  This allows to simply run `make` after
configure.ac has been altered without having to worry about manually
running `autoreconf`.  This is particularly useful when configure.ac
has been updated by a VCS pull, as one is likely not to have noticed
the change.