### PR TITLE
vstring: Fix invalid memory access with empty strings

### DIFF
--- a/vstring.c
+++ b/vstring.c
@@ -171,8 +171,8 @@ extern void vStringStripLeading (vString *const string)
  */
 extern void vStringStripTrailing (vString *const string)
 {
-	while (isspace ((int) string->buffer [string->length - 1]) &&
-		   string->length > 0)
+	while (string->length > 0 &&
+		   isspace ((int) string->buffer [string->length - 1]))
 	{
 		string->length--;
 		string->buffer [string->length] = '\0';


### PR DESCRIPTION
Fix invalid memory access when vStringStripTrailing() is called on a
zero-length string.

See https://github.com/fishman/ctags/pull/272#commitcomment-10592939