### PR TITLE
Add removal of autom4te.cache to maintainerclean target

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -341,6 +341,7 @@ distclean: clean
 
 maintainerclean: distclean
 	rm -f $(AUTO_GEN)
+	rm -rf autom4te.cache/
 
 #
 # implicit rules


### PR DESCRIPTION
At the moment the directory ``autom4te.cache`` is not removed when ``make maintainclean`` is used.
This PR fixes that.