### PR TITLE
Cork, new API for holding and recording scope information

### DIFF
--- a/docs/internal.rst
+++ b/docs/internal.rst
@@ -1,2 +1,103 @@
 ctags Internal
 ============================================================
+
+cork API
+------------------------------------------------------------
+
+Background and Idea
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+cork API is introduced for recording scope information easier.
+
+Before introducing cork, a scope information must be recorded as
+strings. It is flexible but memory management is required.
+Following code is taken from clojure.c(with modifications).
+
+.. code-block:: c
+
+		if (vStringLength (parent) > 0)
+		{
+			current.extensionFields.scope[0] = ClojureKinds[K_NAMESPACE].name;
+			current.extensionFields.scope[1] = vStringValue (parent);
+		}
+
+		makeTagEntry (&current);
+
+`parent`, values stored to `scope [0]` and `scope [1]` are all
+something string.
+
+cork API provides more solid way to hold scope information. cork API
+expects `parent`, which represents scope of a tag(`current`)
+currently parser dealing, is recorded to a *tags* file before recording
+the `current` tag via `makeTagEntry` function.
+
+For passing the information about `parent` to `makeTagEntry`,
+`tagEntryInfo` object was created. It was used just for recording; and
+freed after recording.  In cork API, it is not freed after recording;
+a parser can reused it as scope information.
+
+How to use
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+See a commit titled with "clojure: use cork". I applied cork
+API to the clojure parser.
+
+cork can be enabled and disabled per parser.
+cork is disabled by default. So there is no impact till you
+enables it in your parser.
+
+`use_cork` field is introduced in `parserDefinition` type:
+
+.. code-block:: c
+
+		typedef struct {
+		...
+				boolean use_cork;
+		...
+		} parserDefinition;
+
+Set `TRUE` to `use_cork` like:
+
+.. code-block:: c
+
+    extern parserDefinition *ClojureParser (void)
+    {
+	    ...
+	    parserDefinition *def = parserNew ("Clojure");
+	    ...
+	    def->use_cork = TRUE;
+	    return def;
+    }
+
+When ctags running a parser with use_cork being `TRUE`, all output
+requested via `makeTagEntry` function calling is stored to an internal
+queue, not to `tags` file.  When parsing an input file is done, the
+tag information stored automatically to the queue are flushed to
+`tags` file in batch.
+
+When calling `makeTagEntry` with a `tagEntryInfo` object(`parent`),
+it returns an integer. The integer can be used as handle for referring
+the object after calling.
+
+
+.. code-block:: c
+
+		static int parent = SCOPE_NIL;
+		...
+		parent = makeTagEntry (&e);
+
+The handle can be used by setting to a `scope_index`
+field of `current` tag, which is in the scope of `parent`.
+
+.. code-block:: c
+
+		current.extensionFields.scope_index = parent;
+
+When passing `current` to `makeTagEntry`, the `scope_index` is
+refereed for emitting the scope information of `current`.
+
+`scope_index` must be set to `SCOPE_NIL` if a tag is not in any scope.
+When using `scope_index` of `current`, `NULL` must be assigned to both
+`current.extensionFields.scope[0]` and
+`current.extensionFields.scope[1]`.  `initTagEntry` function does this
+initialization internally, so you generally you don't have to write
+the initialization explicitly.

--- a/entry.c
+++ b/entry.c
@@ -763,12 +763,23 @@ static int addExtensionFields (const tagEntryInfo *const tag)
 	if (Option.extensionFields.language  &&  tag->language != NULL)
 		length += fprintf (TagFile.fp, "%s\tlanguage:%s", sep, tag->language);
 
-	if (Option.extensionFields.scope  &&
-			tag->extensionFields.scope [0] != NULL  &&
-			tag->extensionFields.scope [1] != NULL)
-		length += fprintf (TagFile.fp, "%s\t%s:%s", sep,
-				tag->extensionFields.scope [0],
-				tag->extensionFields.scope [1]);
+	if (Option.extensionFields.scope)
+	{
+		if (tag->extensionFields.scope [0] != NULL  &&
+		    tag->extensionFields.scope [1] != NULL)
+			length += fprintf (TagFile.fp, "%s\t%s:%s", sep,
+					   tag->extensionFields.scope [0],
+					   tag->extensionFields.scope [1]);
+		else if (tag->extensionFields.scope_index != SCOPE_NIL
+			 && TagFile.corkQueue.count > 0)
+		{
+			const tagEntryInfo * scope;
+
+			scope = getEntryInCorkQueue (tag->extensionFields.scope_index);
+			length += fprintf (TagFile.fp, "%s\t%s:%s", sep,
+					   scope->kindName, scope->name);
+		}
+	}
 
 	if (Option.extensionFields.typeRef  &&
 			tag->extensionFields.typeRef [0] != NULL  &&
@@ -1065,6 +1076,7 @@ extern void initTagEntryFull (tagEntryInfo *const e, const char *const name,
 	e->filePosition    = filePosition;
 	e->sourceFileName  = sourceFileName;
 	e->name            = name;
+	e->extensionFields.scope_index     = SCOPE_NIL;
 }
 
 /* vi:set tabstop=4 shiftwidth=4: */

--- a/entry.c
+++ b/entry.c
@@ -81,7 +81,13 @@ tagFile TagFile = {
     { 0, 0 },           /* numTags */
     { 0, 0, 0 },        /* max */
     { NULL, NULL, 0 },  /* etags */
-    NULL                /* vLine */
+    NULL,                /* vLine */
+    .cork = FALSE,
+    .corkQueue = {
+	    .queue = NULL,
+	    .length = 0,
+	    .count  = 0
+    }
 };
 
 static boolean TagsToStdout = FALSE;
@@ -584,12 +590,7 @@ extern void endEtagsFile (const char *const name)
  *  Tag entry management
  */
 
-/*  This function copies the current line out to a specified file. It has no
- *  effect on the fileGetc () function.  During copying, any '\' characters
- *  are doubled and a leading '^' or trailing '$' is also quoted. End of line
- *  characters (line feed or carriage return) are dropped.
- */
-static size_t writeSourceLine (FILE *const fp, const char *const line)
+static size_t appendSourceLine ( void putc_func (char , void *), const char *const line, void * data)
 {
 	size_t length = 0;
 	const char *p;
@@ -609,13 +610,35 @@ static size_t writeSourceLine (FILE *const fp, const char *const line)
 		if (c == BACKSLASH  ||  c == (Option.backward ? '?' : '/')  ||
 			(c == '$'  &&  (next == NEWLINE  ||  next == CRETURN)))
 		{
-			putc (BACKSLASH, fp);
+			putc_func (BACKSLASH, data);
 			++length;
 		}
-		putc (c, fp);
+		putc_func (c, data);
 		++length;
 	}
 	return length;
+}
+
+static void vstring_putc (char c, void *data)
+{
+	vString *str = data;
+	vStringPut (str, c);
+}
+
+static void file_putc (char c, void *data)
+{
+	FILE *fp = data;
+	putc (c, fp);
+}
+
+/*  This function copies the current line out to a specified file. It has no
+ *  effect on the fileGetc () function.  During copying, any '\' characters
+ *  are doubled and a leading '^' or trailing '$' is also quoted. End of line
+ *  characters (line feed or carriage return) are dropped.
+ */
+static size_t writeSourceLine (FILE *const fp, const char *const line)
+{
+	return appendSourceLine (file_putc, line, fp);
 }
 
 /*  Writes "line", stripping leading and duplicate white space.
@@ -780,6 +803,29 @@ static int addExtensionFields (const tagEntryInfo *const tag)
 #undef sep
 }
 
+static char* makePatternString (const tagEntryInfo *const tag)
+{
+	char *const line = readSourceLine (TagFile.vLine, tag->filePosition, NULL);
+	const int searchChar = Option.backward ? '?' : '/';
+	boolean newlineTerminated;
+	vString* pattern;
+
+	pattern = vStringNew ();
+	if (line == NULL)
+		error (FATAL, "bad tag in %s", vStringValue (File.name));
+	if (tag->truncateLine)
+		truncateTagLine (line, tag->name, FALSE);
+	newlineTerminated = (boolean) (line [strlen (line) - 1] == '\n');
+
+	vStringPut (pattern, searchChar);
+	vStringPut (pattern, '^');
+	appendSourceLine (vstring_putc, line, pattern);
+	vStringCatS (pattern, newlineTerminated ? "$":"");
+	vStringPut (pattern, searchChar);
+
+	return vStringDeleteUnwrap (pattern);
+}
+
 static int writePatternEntry (const tagEntryInfo *const tag)
 {
 	char *const line = readSourceLine (TagFile.vLine, tag->filePosition, NULL);
@@ -825,8 +871,145 @@ static int writeCtagsEntry (const tagEntryInfo *const tag)
 	return length;
 }
 
-extern void makeTagEntry (const tagEntryInfo *const tag)
+static void recordCtagsEntryInQueue (const tagEntryInfo *const tag, tagEntryInfo* slot)
 {
+	*slot = *tag;
+
+	if (slot->pattern)
+		slot->pattern = eStrdup (slot->pattern);
+	else if (!slot->lineNumberEntry)
+		slot->pattern = makePatternString (slot);
+
+	slot->sourceFileName = eStrdup (slot->sourceFileName);
+	slot->name = eStrdup (slot->name);
+	if (slot->extensionFields.access)
+		slot->extensionFields.access = eStrdup (slot->extensionFields.access);
+	if (slot->extensionFields.fileScope)
+		slot->extensionFields.fileScope = eStrdup (slot->extensionFields.fileScope);
+	if (slot->extensionFields.implementation)
+		slot->extensionFields.implementation = eStrdup (slot->extensionFields.implementation);
+	if (slot->extensionFields.inheritance)
+		slot->extensionFields.inheritance = eStrdup (slot->extensionFields.inheritance);
+	if (slot->extensionFields.scope[0])
+		slot->extensionFields.scope[0] = eStrdup (slot->extensionFields.scope[0]);
+	if (slot->extensionFields.scope[1])
+		slot->extensionFields.scope[1] = eStrdup (slot->extensionFields.scope[1]);
+	if (slot->extensionFields.signature)
+		slot->extensionFields.signature = eStrdup (slot->extensionFields.signature);
+	if (slot->extensionFields.typeRef[0])
+		slot->extensionFields.typeRef[0] = eStrdup (slot->extensionFields.typeRef[0]);
+	if (slot->extensionFields.typeRef[1])
+		slot->extensionFields.typeRef[1] = eStrdup (slot->extensionFields.typeRef[1]);
+}
+
+static void clearCtagsEntryInQueue (tagEntryInfo* slot)
+{
+	if (slot->pattern)
+		eFree ((char *)slot->pattern);
+	eFree ((char *)slot->sourceFileName);
+	eFree ((char *)slot->name);
+
+	if (slot->extensionFields.access)
+		eFree ((char *)slot->extensionFields.access);
+	if (slot->extensionFields.fileScope)
+		eFree ((char *)slot->extensionFields.fileScope);
+	if (slot->extensionFields.implementation)
+		eFree ((char *)slot->extensionFields.implementation);
+	if (slot->extensionFields.inheritance)
+		eFree ((char *)slot->extensionFields.inheritance);
+	if (slot->extensionFields.scope[0])
+		eFree ((char *)slot->extensionFields.scope[0]);
+	if (slot->extensionFields.scope[1])
+		eFree ((char *)slot->extensionFields.scope[1]);
+	if (slot->extensionFields.signature)
+		eFree ((char *)slot->extensionFields.signature);
+	if (slot->extensionFields.typeRef[0])
+		eFree ((char *)slot->extensionFields.typeRef[0]);
+	if (slot->extensionFields.typeRef[1])
+		eFree ((char *)slot->extensionFields.typeRef[1]);
+}
+
+void corkTagFile(void)
+{
+	TagFile.cork++;
+	if (TagFile.cork == 1)
+	{
+		  TagFile.corkQueue.length = 1;
+		  TagFile.corkQueue.count = 1;
+		  TagFile.corkQueue.queue = eMalloc (sizeof (*TagFile.corkQueue.queue));
+		  memset (TagFile.corkQueue.queue, 0, sizeof (*TagFile.corkQueue.queue));
+	}
+}
+
+void uncorkTagFile(void)
+{
+	unsigned int i;
+	tagEntryInfo  *tag;
+	int length = 0;
+
+	TagFile.cork--;
+
+	if (TagFile.cork > 0)
+		return ;
+
+	for (i = 1; i < TagFile.corkQueue.count; i++)
+	{
+		tag = TagFile.corkQueue.queue + i;
+		length = writeCtagsEntry (tag);
+		rememberMaxLengths (strlen (tag->name), (size_t) length);
+		DebugStatement ( fflush (TagFile.fp); )
+	}
+	for (i = 1; i < TagFile.corkQueue.count; i++)
+		clearCtagsEntryInQueue (TagFile.corkQueue.queue + i);
+
+	memset (TagFile.corkQueue.queue, 0,
+		sizeof (*TagFile.corkQueue.queue) * TagFile.corkQueue.count);
+	TagFile.corkQueue.count = 0;
+
+}
+
+tagEntryInfo *getEntryInCorkQueue   (unsigned int n)
+{
+	return TagFile.corkQueue.queue + n;
+}
+
+size_t        countEntryInCorkQueue (void)
+{
+	return TagFile.corkQueue.count;
+}
+
+
+static unsigned int queueCtagsEntry(const tagEntryInfo *const tag)
+{
+	unsigned int i;
+	void *tmp;
+	tagEntryInfo * slot;
+
+	if (! (TagFile.corkQueue.count < TagFile.corkQueue.length))
+	{
+		if (!TagFile.corkQueue.length )
+			TagFile.corkQueue.length = 1;
+
+		tmp = eRealloc (TagFile.corkQueue.queue,
+				sizeof (*TagFile.corkQueue.queue) * TagFile.corkQueue.length * 2);
+
+		TagFile.corkQueue.length *= 2;
+		TagFile.corkQueue.queue = tmp;
+	}
+
+	i = TagFile.corkQueue.count;
+	TagFile.corkQueue.count++;
+
+
+	slot = TagFile.corkQueue.queue + i;
+	recordCtagsEntryInQueue (tag, slot);
+
+	return i;
+}
+
+extern int makeTagEntry (const tagEntryInfo *const tag)
+{
+	int r = -1;
 	Assert (tag->name != NULL);
 	if (tag->name [0] == '\0')
 		error (WARNING, "ignoring null tag in %s", vStringValue (File.name));
@@ -843,7 +1026,12 @@ extern void makeTagEntry (const tagEntryInfo *const tag)
 		else if (Option.etags)
 			length = writeEtagsEntry (tag);
 		else
-			length = writeCtagsEntry (tag);
+		{
+			if (TagFile.cork)
+				r = queueCtagsEntry (tag);
+			else
+				length = writeCtagsEntry (tag);
+		}
 
 		++TagFile.numTags.added;
 		rememberMaxLengths (strlen (tag->name), (size_t) length);
@@ -851,6 +1039,7 @@ extern void makeTagEntry (const tagEntryInfo *const tag)
 
 		abort_if_ferror (TagFile.fp);
 	}
+	return r;
 }
 
 extern void initTagEntry (tagEntryInfo *const e, const char *const name)

--- a/entry.h
+++ b/entry.h
@@ -78,7 +78,14 @@ typedef struct sTagEntryInfo {
 		const char* fileScope;
 		const char* implementation;
 		const char* inheritance;
+
 		const char* scope [2];    /* value and key */
+#define SCOPE_NIL 0
+		int         scope_index;  /* cork queue entry for upper scope tag.
+					     This field is meaningful if the value
+					     is not SCOPE_NIL and scope[0]  and scope[1] are
+					     NULL. */
+
 		const char* signature;
 
 		/* type (union/struct/etc.) and name for a variable or typedef. */

--- a/entry.h
+++ b/entry.h
@@ -29,6 +29,7 @@
 
 /*  Maintains the state of the tag file.
  */
+struct sTagEntryInfo;
 typedef struct eTagFile {
 	char *name;
 	char *directory;
@@ -41,6 +42,13 @@ typedef struct eTagFile {
 		size_t byteCount;
 	} etags;
 	vString *vLine;
+
+	unsigned int cork;
+	struct sCorkQueue {
+		struct sTagEntryInfo* queue;
+		unsigned int length;
+		unsigned int count;
+	} corkQueue;
 } tagFile;
 
 typedef struct sTagFields {
@@ -95,7 +103,7 @@ extern void openTagFile (void);
 extern void closeTagFile (const boolean resize);
 extern void beginEtagsFile (void);
 extern void endEtagsFile (const char *const name);
-extern void makeTagEntry (const tagEntryInfo *const tag);
+extern int makeTagEntry (const tagEntryInfo *const tag);
 extern void initTagEntry (tagEntryInfo *const e, const char *const name);
 extern void initTagEntryFull (tagEntryInfo *const e, const char *const name,
 			      unsigned long lineNumber,
@@ -108,6 +116,11 @@ extern void writePseudoTag (const char *const tagName,
 			    const char *const fileName,
 			    const char *const pattern,
 			    const char *const language);
+
+void          corkTagFile(void);
+void          uncorkTagFile(void);
+tagEntryInfo *getEntryInCorkQueue   (unsigned int n);
+size_t        countEntryInCorkQueue (void);
 
 #endif  /* _ENTRY_H */
 

--- a/parse.c
+++ b/parse.c
@@ -1670,10 +1670,16 @@ extern boolean parseFile (const char *const fileName)
 		if (Option.filter)
 			openTagFile ();
 
+		if (LanguageTable [language]->use_cork)
+			corkTagFile();
+
 		tagFileResized = createTagsWithFallback (fileName, language);
 #ifdef HAVE_COPROC
 		tagFileResized = invokeXcmd (fileName, language)? TRUE: tagFileResized;
 #endif
+
+		if (LanguageTable [language]->use_cork)
+			uncorkTagFile();
 
 		if (Option.filter)
 			closeTagFile (tagFileResized);

--- a/parse.h
+++ b/parse.h
@@ -85,6 +85,7 @@ typedef struct {
 	rescanParserWithExceptionAndTrash parser_with_gc;          /* rescanning parser (unusual case) */
 	unsigned int method;           /* See PARSE__... definitions above */
 	tgTableEntry *tg_entries;
+	boolean use_cork;
 
 	/* used internally */
 	unsigned int id;               /* id assigned to language */

--- a/parsers/clojure.c
+++ b/parsers/clojure.c
@@ -26,7 +26,7 @@ static kindOption ClojureKinds[] = {
 	{TRUE, 'n', "namespace", "namespaces"}
 };
 
-static vString *CurrentNamespace;
+static int CurrentNamespace = SCOPE_NIL;
 
 static int isNamespace (const char *strp)
 {
@@ -64,20 +64,19 @@ static void functionName (vString * const name, const char *dbp)
 
 static void makeNamespaceTag (vString * const name, const char *dbp)
 {
-	vStringClear (CurrentNamespace);
+	CurrentNamespace = SCOPE_NIL;
 
 	functionName (name, dbp);
-	vStringCopy (CurrentNamespace, name);
-	if (vStringLength (CurrentNamespace) > 0)
+	if (vStringLength (name) > 0)
 	{
 		tagEntryInfo e;
-		initTagEntry (&e, vStringValue (CurrentNamespace));
+		initTagEntry (&e, vStringValue (name));
 		e.lineNumber = getSourceLineNumber ();
 		e.filePosition = getInputFilePosition ();
 		e.kindName = ClojureKinds[K_NAMESPACE].name;
 		e.kind = (char) ClojureKinds[K_NAMESPACE].letter;
 
-		makeTagEntry (&e);
+		CurrentNamespace = makeTagEntry (&e);
 	}
 }
 
@@ -93,11 +92,8 @@ static void makeFunctionTag (vString * const name, const char *dbp)
 		e.kindName = ClojureKinds[K_FUNCTION].name;
 		e.kind = (char) ClojureKinds[K_FUNCTION].letter;
 
-		if (vStringLength (CurrentNamespace) > 0)
-		{
-			e.extensionFields.scope[0] = ClojureKinds[K_NAMESPACE].name;
-			e.extensionFields.scope[1] = vStringValue (CurrentNamespace);
-		}
+		if (CurrentNamespace >= 0)
+			e.extensionFields.scope_index =  CurrentNamespace;
 
 		makeTagEntry (&e);
 	}
@@ -115,7 +111,6 @@ static void findClojureTags (void)
 {
 	vString *name = vStringNew ();
 	const char *p;
-	CurrentNamespace = vStringNew ();
 
 	while ((p = (char *)fileReadLine ()) != NULL)
 	{
@@ -139,7 +134,6 @@ static void findClojureTags (void)
 		}
 	}
 	vStringDelete (name);
-	vStringDelete (CurrentNamespace);
 }
 
 extern parserDefinition *ClojureParser (void)
@@ -157,6 +151,7 @@ extern parserDefinition *ClojureParser (void)
 	def->extensions = extensions;
 	def->aliases = aliases;
 	def->parser = findClojureTags;
+	def->use_cork = TRUE;
 	return def;
 }
 


### PR DESCRIPTION
See "docs: write about cork API" about API.
New API is just applies to clojure.c. If this patch set is accepted, I will work on the other
parsers.