### PR TITLE
lxcmd: accept -x and -e option

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -630,19 +630,8 @@ generator and exuberant-ctags. This is the reason why the name
 *drivers* is used as part of built-in search path.
 
 To write a driver for a tags generator, please read
-"xcmd protocol and writing a driver".
+-"xcmd protocol and writing a driver".
 
-There are some restrictions of utilizing the xcmds:
-
-doesn't work with ``-x``.
-
-  ctags cannot generate cross reference file if
-  ``--<LANG>-xcmd=COMMAND`` is specified.
-
-doesn't work with ``-e``.
-
-  ctags cannot generate TAGS, etags format output
-  if ``--<LANG>-xcmd=COMMAND`` is specified.
 
 Notice message and --quiet option
 ---------------------------------------------------------------------

--- a/lxcmd.c
+++ b/lxcmd.c
@@ -823,6 +823,8 @@ static boolean makeTagEntryFromTagEntry (tagEntry* entry)
 			return FALSE;
 		else if (Option.xref)
 			return FALSE;
+		else if (Option.etags)
+			return FALSE;
 		else
 			return makePseudoTagEntryFromTagEntry (entry);
 	}
@@ -953,19 +955,6 @@ extern boolean invokeXcmd (const char* const fileName, const langType language)
 	{
 		const pathSet* const set = Sets + language;
 		unsigned int i;
-
-		if (Option.xref)
-		{
-			error (WARNING, "Xcmd(%s) does not support generating cross reference(xref, -x) for input %s",
-			       getLanguageName (language), fileName);
-			return FALSE;
-		}
-		else if (Option.etags)
-		{
-			error (WARNING, "Xcmd(%s) does not support generating etags(TAGS) file for input %s",
-			       getLanguageName (language), fileName);
-			return FALSE;
-		}
 
 		for (i = 0; i < set->count ; ++i)
 		{

--- a/parse.c
+++ b/parse.c
@@ -1632,6 +1632,29 @@ static boolean createTagsWithFallback (
 	return tagFileResized;
 }
 
+static boolean createTagsWithXcmd (
+		const char *const fileName, const langType language)
+{
+	boolean tagFileResized = FALSE;
+
+	if (fileOpen (fileName, language))
+	{
+		if (Option.etags)
+			beginEtagsFile ();
+
+		tagFileResized = invokeXcmd (fileName, language);
+
+		if (Option.etags)
+			endEtagsFile (getSourceFileTagPath ());
+
+		/* TODO: File.lineNumber must be adjusted for the case
+		*  Option.printTotals is non-zero. */
+		fileClose ();
+	}
+
+	return tagFileResized;
+}
+
 static void printGuessedParser (const char* const fileName, langType language)
 {
 	const char *parserName;
@@ -1672,7 +1695,7 @@ extern boolean parseFile (const char *const fileName)
 
 		tagFileResized = createTagsWithFallback (fileName, language);
 #ifdef HAVE_COPROC
-		tagFileResized = invokeXcmd (fileName, language)? TRUE: tagFileResized;
+		tagFileResized = createTagsWithXcmd (fileName, language)? TRUE: tagFileResized;
 #endif
 
 		if (Option.filter)

--- a/read.c
+++ b/read.c
@@ -24,6 +24,15 @@
 #include "routines.h"
 #include "options.h"
 
+#ifdef HAVE_REGCOMP
+# include <ctype.h>
+# include <stddef.h>
+# ifdef HAVE_SYS_TYPES_H
+#  include <sys/types.h>  /* declare off_t (not known to regex.h on FreeBSD) */
+# endif
+# include <regex.h>
+#endif
+
 /*
 *   DATA DEFINITIONS
 */
@@ -557,6 +566,116 @@ extern char *readSourceLine (
 
 	return result;
 }
+
+#ifdef HAVE_REGEX
+/* If a xcmd parser is used, ctags cannot know the location for a tag.
+ * In the other hand, etags output and cross reference output require the
+ * line after the location.
+ *
+ * readSourceLineSlow retrieves the line for (lineNumber and pattern of a tag).
+ */
+
+extern char *readSourceLineSlow (vString *const vLine,
+				 unsigned long lineNumber,
+				 const char *pattern,
+				 long *const pSeekValue)
+{
+	char *result = NULL;
+
+
+	fpos_t orignalPosition;
+	char *line;
+	size_t len;
+	long pos;
+
+	regex_t patbuf;
+	char lastc;
+
+
+	/*
+	 * Compile the pattern
+	 */
+	{
+		char *pat;
+		int errcode;
+		char errmsg[256];
+
+		pat = eStrdup (pattern);
+		pat[strlen(pat) - 1] = '\0';
+		errcode = regcomp (&patbuf, pat + 1, 0);
+		eFree (pat);
+
+		if (errcode != 0)
+		{
+			regerror (errcode, &patbuf, errmsg, 256);
+			error (WARNING, "regcomp %s in readSourceLineSlow: %s", pattern, errmsg);
+			regfree (&patbuf);
+			return NULL;
+		}
+	}
+
+	/*
+	 * Get the line for lineNumber
+	 */
+	{
+		int n;
+
+		fgetpos (File.fp, &orignalPosition);
+		rewind (File.fp);
+		line = NULL;
+		pos = 0;
+		for (n = 0; n < lineNumber; n++)
+		{
+			pos = ftell (File.fp);
+			line = readLine (vLine, File.fp);
+			if (line == NULL)
+				break;
+		}
+		if (line == NULL)
+			goto out;
+		else
+			len = strlen(line);
+
+		if (len == 0)
+			goto out;
+
+		lastc = line[len - 1];
+		if (lastc == '\n')
+			line[len - 1] = '\0';
+	}
+
+	/*
+	 * Match
+	 */
+	{
+		regmatch_t pmatch;
+		int after_newline = 0;
+		if (regexec (&patbuf, line, 1, &pmatch, 0) == 0)
+		{
+			line[len - 1] = lastc;
+			result = line + pmatch.rm_so;
+			if (pSeekValue)
+			{
+				after_newline = ((lineNumber == 1)? 0: 1);
+				*pSeekValue = pos + after_newline + pmatch.rm_so;
+			}
+		}
+	}
+
+out:
+	regfree (&patbuf);
+	fsetpos (File.fp, &orignalPosition);
+	return result;
+}
+#else
+extern char *readSourceLineSlow (vString *const vLine,
+				 unsigned long lineNumber,
+				 const char *pattern,
+				 long *const pSeekValue)
+{
+	return NULL;
+}
+#endif
 
 /*
  *   Similar to readLine but this doesn't use fgetpos/fsetpos.

--- a/read.h
+++ b/read.h
@@ -110,7 +110,7 @@ extern void fileUngetc (int c);
 extern const unsigned char *fileReadLine (void);
 extern char *readLine (vString *const vLine, FILE *const fp);
 extern char *readSourceLine (vString *const vLine, fpos_t location, long *const pSeekValue);
-
+extern char *readSourceLineSlow (vString *const vLine, unsigned long lineNumber, const char *pattern, long *const pSeekValue);
 extern char* readLineWithNoSeek (vString *const vline, FILE *const pp);
 
 #endif  /* _READ_H */


### PR DESCRIPTION
xcmd backend cannot provide locations(positions in the source file)
for each tag entries to ctags. The locations don't recorded in a tags
file but are needed for generating a cross reference and TAGS file.

Therefore xcmd has a restriction: it doesn't work with -x and/or -e
options.  In this commit I introduced location
resolver(readSourceLineSlow) to remove the restriction. As the name
shown it is very slow but better than nothing.

Now xcmd based parsers are really first class citizens in ctags world.

Here is the example of generating the corss reference using coffeetags
backend:

%  ./ctags -x --data-dir=./data --libexec-dir=./libexec --options=coffee Units/xcmd-coffeetags.d/input.coffee
Animal           class         3 Units/xcmd-coffeetags.d/input.coffee class Animal
Horse            class        14 Units/xcmd-coffeetags.d/input.coffee class Horse extends Animal
Snake            class         9 Units/xcmd-coffeetags.d/input.coffee class Snake extends Animal
constructor      function      4 Units/xcmd-coffeetags.d/input.coffee constructor: (@name) ->
move             function      6 Units/xcmd-coffeetags.d/input.coffee move: (meters) ->
move             function     10 Units/xcmd-coffeetags.d/input.coffee move: ->
move             function     15 Units/xcmd-coffeetags.d/input.coffee move: ->