### PR TITLE
Allow to run make from "main" and "parsers" sub-directories

### DIFF
--- a/main/Makefile
+++ b/main/Makefile
@@ -1,0 +1,8 @@
+all:
+.SUFFIXES:
+.SUFFIXES: .c .o
+
+.c.o:
+	$(MAKE) -C .. main/$@
+%:
+	$(MAKE) -C .. $@

--- a/parsers/Makefile
+++ b/parsers/Makefile
@@ -1,0 +1,8 @@
+all:
+.SUFFIXES:
+.SUFFIXES: .c .o
+
+.c.o:
+	$(MAKE) -C .. parsers/$@
+%:
+	$(MAKE) -C .. $@


### PR DESCRIPTION
This tries to address @techee's comment https://github.com/fishman/ctags/pull/298#issuecomment-97243973  @techee, does this actually solves your issue?

Note that the code here is particularly adapted for running against #298 (as it asks for `parsers/$@` and not `$@`, e.g. object files in sub-directories), but also work fine on current master, as currently asking for e.g. `parsers/go.o` will involve the rule `.c.o` on `parsers/go.c`, rule that will generate `go.o` (and not the asked `parsers/go.o`, but that's what we want).