### PR TITLE
lregex: Introduce kind ghost

### DIFF
--- a/data/optlib/m4.ctags
+++ b/data/optlib/m4.ctags
@@ -32,7 +32,7 @@
 ##
 ## Ignore comments
 ##
---m4-regex=/^dnl.*$//c/{exclusive}
+--m4-regex=/^dnl.*$//{exclusive}
 
 ##
 ## define

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -556,7 +556,8 @@ If an empty name pattern(``//``) is found in ``--regex-<LANG>`` option
 ctags warns it as wrong usage of the option. However, the flags
 ``exclusive`` or ``x`` is specified, the warning is suppressed. This
 is imperfect approach for ignoring text insides comments but it may
-be better than nothing.
+be better than nothing. Ghost kind is assigned to the empty name
+pattern. (See "Ghost kind in regex parser".)
 
 Optional flag in regex
 ---------------------------------------------------------------------
@@ -571,6 +572,15 @@ A user can turn on this pattern with::
 
        --m4-kinds=+I
 
+
+Ghost kind in regex parser
+---------------------------------------------------------------------
+
+If a whitespace is used as a kind letter, it is never printed when
+ctags is called with ``--list-kinds`` option.  This kind is
+automatically assigned to an empty name pattern.
+
+Normally you don't need to know this.
 
 Passing parameter for long regex flag
 ---------------------------------------------------------------------


### PR DESCRIPTION
With {exclusive} flag, line oriented comments can be
ignored effectively. Here is an example taken from
m4 optlib:

    --m4-regex=/^dnl.*$//c,comments/x

Negative side of this feature is that a kind must be
introduced even for ignoring comments. In above example
`c,comments' is introduced. The kind in the definition
can be empty. In such case 'r,regex' is assigned instead.
This default assignment is not suitable for comments.

As the name field in the definition is empty(//), comments captured
by the regex are not recorded to tags file. However, the
kind is appeared when --list-kinds option is used
like:

    $ ./ctags --data-dir=./data --options=m4 --list-kinds=m4
>   c  comments
    d  definition
    I  inclusion  [off]
    u  undefinition

The kind is not for recording but for ignoring. So appearing in
the list is unwanted.

In this patch introduces an internal kind ` ' named ghost kind.
The ghost kind is never list in the option.

Currently specifying the ghost kind explicitly in a pattern
definition is not considered. The ghost kind is assigned
automatically for a pattern with following conditions:

  If the name field of a definition is empty; {exclusive}
  flag is attached to the definition; and the kind field
  of definition is empty, the ghost kind is assigned to
  the pattern definition automatically.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>