### PR TITLE
variables-prototypes.cpp unit: syntax error in args.ctags

### DIFF
--- a/Units/variables-prototypes.cpp.b/args.ctags
+++ b/Units/variables-prototypes.cpp.b/args.ctags
@@ -1,1 +1,2 @@
---c++-kinds=+pl --fields=+S
+--c++-kinds=+pl
+--fields=+S


### PR DESCRIPTION
Just a missing linebreak.