### PR TITLE
c: add <> and "" to include kinds only if --extra=+q is given

### DIFF
--- a/Units/parser-c.r/c-include.d/args.ctags
+++ b/Units/parser-c.r/c-include.d/args.ctags
@@ -1,2 +1,1 @@
---c-kinds=+I
-
+--c-kinds=+Hh

--- a/Units/parser-c.r/c-include.d/expected.tags
+++ b/Units/parser-c.r/c-include.d/expected.tags
@@ -1,13 +1,13 @@
-"../f.h"	input.c	/^#include "..\/f.h"$/;"	I
-"b.h"	input.c	/^#include "b.h"$/;"	I
-"h.h"	input.c	/^#include"h.h"$/;"	I
-"j.h"	input.c	/^#include       "j.h"$/;"	I
-"sys/d.h"	input.c	/^#include "sys\/d.h"$/;"	I
-<../e.h>	input.c	/^#include <..\/e.h>$/;"	I
-<a.h>	input.c	/^#include <a.h>$/;"	I
-<g.h>	input.c	/^#include<g.h>$/;"	I
-<i.h>	input.c	/^#include       <i.h>$/;"	I
-<stdio.h>	input.c	/^   #    	include <stdio.h>$/;"	I
-<sys/c.h>	input.c	/^#include <sys\/c.h>$/;"	I
+../e.h	input.c	/^#include <..\/e.h>/;"	h
+../f.h	input.c	/^#include "..\/f.h"/;"	h
 D	input.c	/^#define D /;"	d	file:
 M	input.c	/^M(void)$/;"	f
+a.h	input.c	/^#include <a.h>/;"	h
+b.h	input.c	/^#include "b.h"/;"	h
+g.h	input.c	/^#include<g.h>/;"	h
+h.h	input.c	/^#include"h.h"/;"	h
+i.h	input.c	/^#include       <i.h>/;"	h
+j.h	input.c	/^#include       "j.h"/;"	h
+stdio.h	input.c	/^   #    	include <stdio.h>/;"	h
+sys/c.h	input.c	/^#include <sys\/c.h>/;"	h
+sys/d.h	input.c	/^#include "sys\/d.h"/;"	h

--- a/Units/review-needed.r/jbrown.vr.t/args.ctags
+++ b/Units/review-needed.r/jbrown.vr.t/args.ctags
@@ -1,0 +1,1 @@
+--vera-kinds=+h

--- a/Units/review-needed.r/jbrown.vr.t/expected.tags
+++ b/Units/review-needed.r/jbrown.vr.t/expected.tags
@@ -3,4 +3,5 @@ address	input.vr	/^   rand bit[31:0] address;           \/\/ allow for address t
 data	input.vr	/^   rand bit[31:0] data;              \/\/ allow for data to be random$/;"	m	class:Transaction	file:
 myProgram	input.vr	/^program myProgram {$/;"	p
 new	input.vr	/^   task new( (bit[31:0] address = -1), (bit[31:0] data = -1)) {$/;"	t	class:Transaction	file:
+vera_defines.vrh	input.vr	/^#include <vera_defines.vrh>/;"	h
 writeBus	input.vr	/^   task writeBus() {$/;"	t	class:Transaction	file:

--- a/main/get.c
+++ b/main/get.c
@@ -66,6 +66,7 @@ typedef struct sCppState {
 	boolean hasAtLiteralStrings; /* supports @"c:\" strings */
 	boolean hasSingleQuoteLiteralNumbers; /* supports vera number literals:
 						 'h..., 'o..., 'd..., and 'b... */
+	const kindOption  *defineMacroKind;
 	const kindOption  *headerKind;
 
 	struct sDirective {
@@ -90,6 +91,7 @@ static cppState Cpp = {
 	FALSE,       /* resolveRequired */
 	FALSE,       /* hasAtLiteralStrings */
 	FALSE,	     /* hasSingleQuoteLiteralNumbers */
+	NULL,	     /* defineMacroKind */
 	NULL,	     /* headerKind */
 	{
 		DRCTV_NONE,  /* state */
@@ -116,6 +118,7 @@ extern unsigned int getDirectiveNestLevel (void)
 
 extern void cppInit (const boolean state, const boolean hasAtLiteralStrings,
 		     const boolean hasSingleQuoteLiteralNumbers,
+		     const struct sKindOption *defineMacroKind,
 		     const struct sKindOption *headerKind)
 {
 	BraceFormat = state;
@@ -125,6 +128,7 @@ extern void cppInit (const boolean state, const boolean hasAtLiteralStrings,
 	Cpp.resolveRequired = FALSE;
 	Cpp.hasAtLiteralStrings = hasAtLiteralStrings;
 	Cpp.hasSingleQuoteLiteralNumbers = hasSingleQuoteLiteralNumbers;
+	Cpp.defineMacroKind  = defineMacroKind;
 	Cpp.headerKind  = headerKind;
 
 	Cpp.directive.state     = DRCTV_NONE;
@@ -322,7 +326,7 @@ static void makeDefineTag (const char *const name)
 {
 	const boolean isFileScope = (boolean) (! isHeaderFile ());
 
-	if (includingDefineTags () &&
+	if (Cpp.defineMacroKind && Cpp.defineMacroKind->enabled &&
 		(! isFileScope  ||  Option.include.fileScope))
 	{
 		tagEntryInfo e;
@@ -330,8 +334,8 @@ static void makeDefineTag (const char *const name)
 		e.lineNumberEntry = (boolean) (Option.locate == EX_LINENUM);
 		e.isFileScope  = isFileScope;
 		e.truncateLine = TRUE;
-		e.kindName     = "macro";
-		e.kind         = 'd';
+		e.kindName     = Cpp.defineMacroKind->name;
+		e.kind         = Cpp.defineMacroKind->letter;
 		makeTagEntry (&e);
 	}
 }

--- a/main/get.h
+++ b/main/get.h
@@ -35,8 +35,12 @@
 */
 extern boolean isBraceFormat (void);
 extern unsigned int getDirectiveNestLevel (void);
-extern void cppInit (const boolean state, const boolean hasAtLiteralStrings,
-		     const boolean hasSingleQuoteLiteralNumbers);
+
+struct sKindOption;
+extern void cppInit (const boolean state,
+		     const boolean hasAtLiteralStrings,
+		     const boolean hasSingleQuoteLiteralNumbers,
+		     const struct sKindOption *headerKind);
 extern void cppTerminate (void);
 extern void cppBeginStatement (void);
 extern void cppEndStatement (void);

--- a/main/get.h
+++ b/main/get.h
@@ -40,6 +40,7 @@ struct sKindOption;
 extern void cppInit (const boolean state,
 		     const boolean hasAtLiteralStrings,
 		     const boolean hasSingleQuoteLiteralNumbers,
+		     const struct sKindOption *defineMacroKind,
 		     const struct sKindOption *headerKind);
 extern void cppTerminate (void);
 extern void cppBeginStatement (void);

--- a/main/parse.h
+++ b/main/parse.h
@@ -114,9 +114,6 @@ typedef void (*regexCallback) (const char *line, const regexMatch *matches, unsi
  */
 extern parserDefinitionFunc PARSER_LIST;
 
-/* Legacy interface */
-extern boolean includingDefineTags (void);
-
 /* Language processing and parsing */
 extern void makeSimpleTag (const vString* const name, kindOption* const kinds, const int kind);
 extern parserDefinition* parserNew (const char* name);

--- a/main/parse.h
+++ b/main/parse.h
@@ -116,7 +116,6 @@ extern parserDefinitionFunc PARSER_LIST;
 
 /* Legacy interface */
 extern boolean includingDefineTags (void);
-extern boolean includingIncludeTags (void);
 
 /* Language processing and parsing */
 extern void makeSimpleTag (const vString* const name, kindOption* const kinds, const int kind);

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -574,11 +574,6 @@ static void createTags (const unsigned int nestLevel, statementInfo *const paren
 *   FUNCTION DEFINITIONS
 */
 
-extern boolean includingDefineTags (void)
-{
-	return CKinds [CK_DEFINE].enabled;
-}
-
 /*
 *   Token management
 */
@@ -3141,6 +3136,7 @@ static rescanReason findCTags (const unsigned int passCount)
 
 	in_c_family = (isLanguage (Lang_c) || isLanguage (Lang_cpp));
 	cppInit ((boolean) (passCount > 1), isLanguage (Lang_csharp), isLanguage(Lang_vera),
+		 in_c_family? CKinds+CK_DEFINE: NULL,
 		 in_c_family? CKinds+CK_HEADER: NULL);
 
 	Signature = vStringNew ();

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -394,7 +394,7 @@ typedef enum {
 	VK_CLASS, VK_DEFINE, VK_ENUMERATOR, VK_FUNCTION,
 	VK_ENUMERATION, VK_LOCAL, VK_MEMBER, VK_PROGRAM, VK_PROTOTYPE,
 	VK_TASK, VK_TYPEDEF, VK_VARIABLE,
-	VK_EXTERN_VARIABLE
+	VK_EXTERN_VARIABLE, VK_HEADER
 } veraKind;
 
 static kindOption VeraKinds [] = {
@@ -410,7 +410,9 @@ static kindOption VeraKinds [] = {
 	{ TRUE,  't', "task",       "tasks"},
 	{ TRUE,  'T', "typedef",    "typedefs"},
 	{ TRUE,  'v', "variable",   "variable definitions"},
-	{ FALSE, 'x', "externvar",  "external variable declarations"}
+	{ FALSE, 'x', "externvar",  "external variable declarations"},
+	{ FALSE, 'h', "system header",   "included system header file name"},
+	{ FALSE, 'H', "local header",    "included local header file name"}
 };
 
 static const keywordDesc KeywordTable [] = {
@@ -3130,14 +3132,25 @@ static rescanReason findCTags (const unsigned int passCount)
 {
 	exception_t exception;
 	rescanReason rescan;
-	boolean in_c_family;
+	kindOption *kind_for_define = NULL;
+	kindOption *kind_for_header = NULL;
 
 	Assert (passCount < 3);
 
-	in_c_family = (isLanguage (Lang_c) || isLanguage (Lang_cpp));
+	if (isLanguage (Lang_c) || isLanguage (Lang_cpp))
+	{
+		kind_for_define = CKinds+CK_DEFINE;
+		kind_for_header = CKinds+CK_HEADER;
+	}
+	else if (isLanguage (Lang_vera))
+	{
+		kind_for_define = VeraKinds+VK_DEFINE;
+		kind_for_header = VeraKinds+VK_HEADER;
+	}
+
 	cppInit ((boolean) (passCount > 1), isLanguage (Lang_csharp), isLanguage(Lang_vera),
-		 in_c_family? CKinds+CK_DEFINE: NULL,
-		 in_c_family? CKinds+CK_HEADER: NULL);
+		 kind_for_define,
+		 kind_for_header);
 
 	Signature = vStringNew ();
 

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -293,9 +293,9 @@ static int AnonymousID = 0;
 typedef enum {
 	CK_UNDEFINED = COMMONK_UNDEFINED,
 	CK_CLASS, CK_DEFINE, CK_ENUMERATOR, CK_FUNCTION,
-	CK_ENUMERATION, CK_LOCAL, CK_MEMBER, CK_NAMESPACE, CK_PROTOTYPE,
+	CK_ENUMERATION, CK_HEADER, CK_LOCAL, CK_MEMBER, CK_NAMESPACE, CK_PROTOTYPE,
 	CK_STRUCT, CK_TYPEDEF, CK_UNION, CK_VARIABLE,
-	CK_EXTERN_VARIABLE, CK_INCLUDE, CK_LABEL
+	CK_EXTERN_VARIABLE, CK_LABEL
 } cKind;
 
 static kindOption CKinds [] = {
@@ -304,6 +304,7 @@ static kindOption CKinds [] = {
 	{ TRUE,  'e', "enumerator", "enumerators (values inside an enumeration)"},
 	{ TRUE,  'f', "function",   "function definitions"},
 	{ TRUE,  'g', "enum",       "enumeration names"},
+	{ FALSE, 'h', "header",     "included header files"},
 	{ FALSE, 'l', "local",      "local variables"},
 	{ TRUE,  'm', "member",     "class, struct, and union members"},
 	{ TRUE,  'n', "namespace",  "namespaces"},
@@ -313,7 +314,6 @@ static kindOption CKinds [] = {
 	{ TRUE,  'u', "union",      "union names"},
 	{ TRUE,  'v', "variable",   "variable definitions"},
 	{ FALSE, 'x', "externvar",  "external and forward variable declarations"},
-	{ FALSE, 'I', "include",    "included file name"},
 	{ FALSE, 'L', "label",      "goto label"},
 };
 
@@ -577,11 +577,6 @@ static void createTags (const unsigned int nestLevel, statementInfo *const paren
 extern boolean includingDefineTags (void)
 {
 	return CKinds [CK_DEFINE].enabled;
-}
-
-extern boolean includingIncludeTags (void)
-{
-	return CKinds [CK_INCLUDE].enabled;
 }
 
 /*
@@ -3140,9 +3135,14 @@ static rescanReason findCTags (const unsigned int passCount)
 {
 	exception_t exception;
 	rescanReason rescan;
+	boolean in_c_family;
 
 	Assert (passCount < 3);
-	cppInit ((boolean) (passCount > 1), isLanguage (Lang_csharp), isLanguage(Lang_vera));
+
+	in_c_family = (isLanguage (Lang_c) || isLanguage (Lang_cpp));
+	cppInit ((boolean) (passCount > 1), isLanguage (Lang_csharp), isLanguage(Lang_vera),
+		 in_c_family? CKinds+CK_HEADER: NULL);
+
 	Signature = vStringNew ();
 
 	exception = (exception_t) setjmp (Exception);


### PR DESCRIPTION
In c917dc681cf44ebdbe21bcb9d2400f4fa9e0eb34, I introduced
'I' kind to C parser to record the name of included header files.

For containing more information separators around the file names (<,
", >) are recorded. After thinking this is too aggressive as default
behavior.

With this patch the separators are recorded only if
--extra=+q. By default only the names of header files without
separators are recorded. If --extra=+q is given both type of tags are
recorded: only a name of header file and a name of header file with
separators.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>