### PR TITLE
C#: Don't ignore the character following an '@'

### DIFF
--- a/main/get.c
+++ b/main/get.c
@@ -753,6 +753,8 @@ process:
 						c = skipToEndOfString (TRUE);
 						break;
 					}
+					else
+						fileUngetc (next);
 				}
 			enter:
 				Cpp.directive.accept = FALSE;


### PR DESCRIPTION
The character following an '@' was dropped if it didn't start a string literal.

This could lead to unexpected problems if '@' was valid in other situations.

---

This change has currently no effect, but could come in handy if at some point anyone is interested with the character following an `@` when the language `hasAtLiteralStrings`.