### PR TITLE
recognize Fortran procedure pointers as variables

### DIFF
--- a/Units/fortran-procedure.d/expected.tags
+++ b/Units/fortran-procedure.d/expected.tags
@@ -1,0 +1,4 @@
+a	input.f90	/^  real/;"	v	module:proc_pointer
+my_pointer	input.f90	/^  procedure(sub), pointer :: my_pointer$/;"	v	module:proc_pointer
+proc_pointer	input.f90	/^module proc_pointer$/;"	m
+sub	input.f90	/^  subr/;"	s	module:proc_pointer

--- a/Units/fortran-procedure.d/input.f90
+++ b/Units/fortran-procedure.d/input.f90
@@ -1,0 +1,19 @@
+! a module that uses procedure pointer
+module proc_pointer
+
+  real :: a
+  procedure(sub), pointer :: my_pointer
+
+contains
+
+  subroutine sub(x)
+    real, intent(inout) :: x(:)
+
+    integer :: i
+
+    do i=1,size(x)
+      x(i) = 0.5**i
+    end do
+  end subroutine sub
+
+end module proc_pointer

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -110,6 +110,7 @@ typedef enum eKeywordId {
 	KEYWORD_pointer,
 	KEYWORD_precision,
 	KEYWORD_private,
+	KEYWORD_procedure,
 	KEYWORD_program,
 	KEYWORD_public,
 	KEYWORD_pure,
@@ -273,6 +274,7 @@ static const keywordDesc FortranKeywordTable [] = {
 	{ "pointer",        KEYWORD_pointer      },
 	{ "precision",      KEYWORD_precision    },
 	{ "private",        KEYWORD_private      },
+	{ "procedure",      KEYWORD_procedure    },
 	{ "program",        KEYWORD_program      },
 	{ "public",         KEYWORD_public       },
 	{ "pure",           KEYWORD_pure         },
@@ -1109,6 +1111,7 @@ static boolean isTypeSpec (tokenInfo *const token)
 		case KEYWORD_logical:
 		case KEYWORD_record:
 		case KEYWORD_type:
+		case KEYWORD_procedure:
 			result = TRUE;
 			break;
 		default:
@@ -1171,6 +1174,7 @@ static void parseTypeSpec (tokenInfo *const token)
 		case KEYWORD_integer:
 		case KEYWORD_logical:
 		case KEYWORD_real:
+		case KEYWORD_procedure:
 			readToken (token);
 			if (isType (token, TOKEN_PAREN_OPEN))
 				skipOverParens (token);  /* skip kind-selector */


### PR DESCRIPTION
Recognize Fortran statement such as:
```Fortran
procedure(subprogram_to_point_to), pointer :: my_pointer
```
Import from Geany https://github.com/geany/geany/commit/194ef6010d25e04bf69f705cf94818f68a55f3fa.