### PR TITLE
Fortran: fix handling of pointer association operator

### DIFF
--- a/Units/fortran-pointer.d/expected.tags
+++ b/Units/fortran-pointer.d/expected.tags
@@ -1,0 +1,12 @@
+Main	input.f90	/^program Main$/;"	p
+MyOtherProc	input.f90	/^  MyOtherProc /;"	v	module:Test
+MyProc	input.f90	/^  procedure(ProcOne), pointer :: MyProc /;"	v	module:Test
+ProcOne	input.f90	/^  function ProcOne(/;"	f	module:Test
+ProcPointOne	input.f90	/^  procedure(:), pointer :: ProcPointOne /;"	v	program:Main
+ProcPointTwo	input.f90	/^  => null(), ProcPointTwo /;"	v	program:Main
+ProcTwo	input.f90	/^  function ProcTwo(/;"	f	module:Test
+Test	input.f90	/^module Test$/;"	m
+myparameter	input.f90	/^  real, parameter :: myparameter$/;"	v	module:Test
+variable	input.f90	/^  real :: variable,/;"	v	program:Main
+variable_three	input.f90	/^  integer :: variable_three$/;"	v	program:Main
+variable_two	input.f90	/^  real :: variable, variable_two$/;"	v	program:Main

--- a/Units/fortran-pointer.d/input.f90
+++ b/Units/fortran-pointer.d/input.f90
@@ -1,0 +1,32 @@
+module Test
+  implicit none
+
+  procedure(ProcOne), pointer :: MyProc => null(), &
+  MyOtherProc => ProcTwo
+  real, parameter :: myparameter
+
+contains
+
+  function ProcOne(arg1, optformat)
+    ! not relevant
+  end function ProcOne
+
+  function ProcTwo(arg1, optformat)
+    ! not relevant
+  end function ProcTwo
+
+end module Test
+
+program Main
+  implicit none
+
+  ! deliberately break up the line to make sure the tagparser doesn't choke on awkward cases
+  procedure(:), pointer :: ProcPointOne &
+  => null(), ProcPointTwo => &
+  null()
+  real :: variable, variable_two
+  integer :: variable_three
+
+  ProcPointOne => ProcTwo
+
+end program Main

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -1327,7 +1327,8 @@ static void parseEntityDecl (tokenInfo *const token)
 			readToken (token);
 			skipPast (token, TOKEN_OPERATOR);
 		}
-		else if (strcmp (vStringValue (token->string), "=") == 0)
+		else if (strcmp (vStringValue (token->string), "=") == 0 ||
+				 strcmp (vStringValue (token->string), "=>") == 0)
 		{
 			while (! isType (token, TOKEN_COMMA) &&
 					! isType (token, TOKEN_STATEMENT_END))


### PR DESCRIPTION
Handling Fortran pointer association as:
```Fortran
procedure(ProcOne), pointer :: MyProc => null()
```
Both of the code and test case are imported from Geany.