### PR TITLE
go: fix missing '-' from '<-' in function prototype

### DIFF
--- a/Units/go-funcs.d/expected.tags
+++ b/Units/go-funcs.d/expected.tags
@@ -2,7 +2,7 @@ T	input.go	/^type T int$/;"	t
 f1	input.go	/^func f1() {$/;"	f	signature:()
 f2	input.go	/^func f2(a int) {$/;"	f	signature:(a int)
 f3	input.go	/^func f3(a int) string {$/;"	f	signature:(a int)
-f4	input.go	/^func f4(a, b, c int, d, e, f string) (A, B, C int, D string) {$/;"	f	signature:(a, b, c int, d, e, f string)
+f4	input.go	/^func f4(a, b, c <-chan int, d, e, f string) (A, B, C int, D string) {$/;"	f	signature:(a, b, c <-chan int, d, e, f string)
 f5	input.go	/^func (t *T) f5(\/* comment *\/ a, \/*comment*\/ \/*comment*\/       b string, $/;"	f	signature:( a, b string, c []int)
 main	input.go	/^func main() {$/;"	f	signature:()
 main	input.go	/^package main$/;"	p

--- a/Units/go-funcs.d/input.go
+++ b/Units/go-funcs.d/input.go
@@ -10,7 +10,7 @@ func f3(a int) string {
 	return ""
 }
 
-func f4(a, b, c int, d, e, f string) (A, B, C int, D string) {
+func f4(a, b, c <-chan int, d, e, f string) (A, B, C int, D string) {
 	return 1, 2, 3, ""
 }
 

--- a/parsers/go.c
+++ b/parsers/go.c
@@ -384,7 +384,9 @@ getNextChar:
 
 	if (signature && vStringLength (signature) < MAX_SIGNATURE_LENGTH)
 	{
-		if (token->type == TOKEN_STRING)
+		if (token->type == TOKEN_LEFT_ARROW)
+			vStringCatS(signature, "<-");
+		else if (token->type == TOKEN_STRING)
 		{
 			// only struct member annotations can appear in function prototypes
 			// so only `` type strings are possible


### PR DESCRIPTION
The whole <- token representation has to be inserted into the prototype,
not just the single character <.

@b4n This is the fix to the problem you observed in Geany.